### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/extension/src/json-viewer/viewer/expose-json.js
+++ b/extension/src/json-viewer/viewer/expose-json.js
@@ -5,8 +5,8 @@ function exposeJson(text, outsideViewer) {
     window.json = JSON.parse(text);
 
   } else {
-    var script = document.createElement("script") ;
-    script.innerHTML = 'window.json = ' + text + ';';
+    var script = document.createElement("script");
+    script.innerHTML = 'window.json = ' + JSON.stringify(JSON.parse(text)) + ';';
     document.head.appendChild(script);
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/krishnprakash/json-viewer/security/code-scanning/1](https://github.com/krishnprakash/json-viewer/security/code-scanning/1)

To fix the problem, we need to ensure that the `text` variable is properly sanitized or escaped before being inserted into the `innerHTML` of the script element. One effective way to do this is to use `JSON.stringify` to safely encode the `text` variable, which will escape any potentially harmful characters.

- In general terms, the problem can be fixed by ensuring that any text content derived from the DOM is properly escaped before being used as HTML.
- Specifically, we will modify the code in `extension/src/json-viewer/viewer/expose-json.js` to use `JSON.stringify` on the `text` variable before inserting it into the `innerHTML` of the script element.
- The changes will be made to the `exposeJson` function in `extension/src/json-viewer/viewer/expose-json.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
