### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/extension/src/json-viewer/viewer/expose-json.js
+++ b/extension/src/json-viewer/viewer/expose-json.js
@@ -6,7 +6,7 @@ function exposeJson(text, outsideViewer) {
 
   } else {
     var script = document.createElement("script");
-    script.innerHTML = 'window.json = ' + JSON.stringify(JSON.parse(text)) + ';';
+    script.textContent = 'window.json = ' + JSON.stringify(JSON.parse(text)) + ';';
     document.head.appendChild(script);
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/krishnprakash/json-viewer/security/code-scanning/2](https://github.com/krishnprakash/json-viewer/security/code-scanning/2)

To fix the problem, we need to ensure that the text content is safely handled and not directly inserted into the DOM as HTML. One effective way to do this is to use `textContent` instead of `innerHTML` when creating the script element. This will prevent the browser from interpreting the text as HTML, thereby mitigating the risk of XSS.

- Replace the use of `innerHTML` with `textContent` for the script element.
- Ensure that the JSON data is properly escaped and handled as plain text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
